### PR TITLE
writeWithColor expects a CSV string as 2nd value

### DIFF
--- a/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
+++ b/src/DiabloMedia/PHPUnit/Printer/PrettyPrinter.php
@@ -51,7 +51,7 @@ class PrettyPrinter extends \PHPUnit\TextUI\ResultPrinter implements \PHPUnit\Fr
             $this->write(' ');
             $this->writeWithColor($timeColor, '['.number_format($time, 3).'s]', false);
             $this->write(' ');
-            $this->writeWithColor('fg-cyan', \PHPUnit\Util\Test::describe($test), true);
+            $this->writeWithColor('fg-cyan', implode(',', \PHPUnit\Util\Test::describe($test)), true);
         }
     }
 


### PR DESCRIPTION
PHPUnit wants to explode a CSV string to make its own array, rather than get passed one.